### PR TITLE
Optimize return type hinting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,3 +67,9 @@ All notable changes to `laravel-helpers` will be documented in this file
 
 ## 2.0.1 - 2021-03-10
 - fix ServiceProvider namespace in composer.json
+
+
+## 2.0.2 - 2021-03-11
+ - optimize return type hinting
+ - reformat linebreaks & whitespace
+ - fix `cacheKey()` method to use config 'cache_prefix' value & cut CACHE_PREFIX const

--- a/src/AppInfo.php
+++ b/src/AppInfo.php
@@ -21,7 +21,7 @@ class AppInfo
 
             // Value to cache
             function () {
-                return trim(config('app-info.version')) . (self::isEnvDevelopment() ? ' (dev)' : '');
+                return trim(config('app-info.version')).(self::isEnvDevelopment() ? ' (dev)' : '');
             }
         );
     }
@@ -199,6 +199,6 @@ class AppInfo
      */
     private static function cacheKey(string $item, string $identifier = null): string
     {
-        return config('app-info.cache_prefix'). ':' . $item . (isset($identifier) ? '#' . $identifier : '');
+        return config('app-info.cache_prefix').':'.$item.(isset($identifier) ? '#'.$identifier : '');
     }
 }

--- a/src/AppInfo.php
+++ b/src/AppInfo.php
@@ -11,9 +11,9 @@ class AppInfo
     /**
      * Retrieve the Application's version.
      *
-     * @return mixed
+     * @return string
      */
-    public static function version()
+    public static function version(): string
     {
         return Cache::rememberForever(
             // Cache key
@@ -21,7 +21,7 @@ class AppInfo
 
             // Value to cache
             function () {
-                return trim(config('app-info.version')).(self::isEnvDevelopment() ? ' (dev)' : '');
+                return trim(config('app-info.version')) . (self::isEnvDevelopment() ? ' (dev)' : '');
             }
         );
     }

--- a/src/AppInfo.php
+++ b/src/AppInfo.php
@@ -11,11 +11,6 @@ class AppInfo
     // todo: add invalidate cache methods
 
     /**
-     * Redis Cache Key prefix.
-     */
-    private const CACHE_PREFIX = 'app';
-
-    /**
      * Retrieve the Application's version.
      *
      * @return mixed

--- a/src/AppInfo.php
+++ b/src/AppInfo.php
@@ -8,8 +8,6 @@ use Sfneal\Helpers\Strings\StringHelpers;
 
 class AppInfo
 {
-    // todo: add invalidate cache methods
-
     /**
      * Retrieve the Application's version.
      *

--- a/src/AppInfo.php
+++ b/src/AppInfo.php
@@ -188,6 +188,6 @@ class AppInfo
      */
     private static function cacheKey(string $item, string $identifier = null): string
     {
-        return self::CACHE_PREFIX.':'.$item.(isset($identifier) ? '#'.$identifier : '');
+        return config('app-info.cache_prefix'). ':' . $item . (isset($identifier) ? '#' . $identifier : '');
     }
 }

--- a/src/AppInfo.php
+++ b/src/AppInfo.php
@@ -17,10 +17,15 @@ class AppInfo
      */
     public static function version()
     {
-        return Cache::rememberForever(self::cacheKey('version'), function () {
-            // toto: refactor environment method to AppInfo
-            return trim(config('app-info.version')).(self::isEnvDevelopment() ? ' (dev)' : '');
-        });
+        return Cache::rememberForever(
+            // Cache key
+            self::cacheKey('version'),
+
+            // Value to cache
+            function () {
+                return trim(config('app-info.version')).(self::isEnvDevelopment() ? ' (dev)' : '');
+            }
+        );
     }
 
     /**
@@ -28,27 +33,34 @@ class AppInfo
      *
      * @param string|null $version
      *
-     * @return mixed
+     * @return array|null
      */
-    public static function versionChanges(string $version = null)
+    public static function versionChanges(string $version = null): ?array
     {
         // Get current version changes if $version wasn't passed
         $version = $version ?? self::version();
 
-        return Cache::rememberForever(self::cacheKey('changelog', $version), function () use ($version) {
-            try {
-                return self::changelog()[$version];
-            } catch (ErrorException $exception) {
+        return Cache::rememberForever(
+            // Cache key
+            self::cacheKey('changelog', $version),
+
+            // Value to cache
+            function () use ($version) {
+                try {
+                    return self::changelog()[$version];
+                } catch (ErrorException $exception) {
+                    return null;
+                }
             }
-        });
+        );
     }
 
     /**
      * Retrieve the Application's changelog.
      *
-     * @return mixed
+     * @return array
      */
-    public static function changelog()
+    public static function changelog(): array
     {
         return Cache::rememberForever(self::cacheKey('changelog'), function () {
             // Read the changelog
@@ -137,9 +149,15 @@ class AppInfo
      */
     public static function isVersionTag(string $tag): bool
     {
-        return Cache::rememberForever(self::cacheKey('version', "is-{$tag}"), function () use ($tag) {
-            return (new StringHelpers(self::version()))->inString($tag);
-        });
+        return Cache::rememberForever(
+            // Cache key
+            self::cacheKey('version', "is-{$tag}"),
+
+            // Value to cache
+            function () use ($tag) {
+                return (new StringHelpers(self::version()))->inString($tag);
+            }
+        );
     }
 
     /**

--- a/src/AppInfo.php
+++ b/src/AppInfo.php
@@ -30,7 +30,6 @@ class AppInfo
      * Retrieve an array of changes made to a particular application version.
      *
      * @param string|null $version
-     *
      * @return array|null
      */
     public static function versionChanges(string $version = null): ?array

--- a/src/AppInfo.php
+++ b/src/AppInfo.php
@@ -8,7 +8,6 @@ use Sfneal\Helpers\Strings\StringHelpers;
 
 class AppInfo
 {
-    // todo: add config values for version?
     // todo: add invalidate cache methods
 
     /**


### PR DESCRIPTION
 - optimize return type hinting
 - reformat linebreaks & whitespace
 - fix `cacheKey()` method to use config 'cache_prefix' value & cut CACHE_PREFIX const