### PR TITLE
Cut use of '#' in cache keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,3 +100,7 @@ All notable changes to `laravel-helpers` will be documented in this file
 
 ## 2.4.0 - 2021-06-21
 - add `LaravelHelpers::percentage()` method for converting decimals to human-readable percentages
+
+
+## 2.4.1 - 2021-09-01
+- cut use of '#' cache key delimiters

--- a/src/Support/CacheKey.php
+++ b/src/Support/CacheKey.php
@@ -25,7 +25,7 @@ class CacheKey extends Action
     public function __construct(string $item, string $identifier = null)
     {
         $this->item = $item;
-        $this->identifier = (isset($identifier) ? '#'.$identifier : '');
+        $this->identifier = (isset($identifier) ? ':'.$identifier : '');
     }
 
     /**


### PR DESCRIPTION
- cut use of '#' cache key delimiters